### PR TITLE
Changed the name EPC/PPC-A8-70HB-C  to  EPC/PPC-A8-70H-C 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,11 +12,11 @@ sphinx:
   fail_on_warning: false
 
 # Optionally build your docs in additional formats such as PDF
-# formats:
-# - pdf
+formats:
+ - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
    version: "3.8"
    install:
-    - requirements: requirements.txt
+    - requirements: docs/source/requirements.txt

--- a/docs/source/PCs/ARM/AM335X/Manuals/Hardware/CS10600T070.rst
+++ b/docs/source/PCs/ARM/AM335X/Manuals/Hardware/CS10600T070.rst
@@ -1,4 +1,4 @@
-.. |product| replace:: PPC/EPC-A8-70-HB-C
+.. |product| replace:: EPC/PPC-A8-70H-C
 
 .. |productE| replace:: EPC-A8-70-HB-C
 
@@ -52,7 +52,11 @@
 
 .. |audio| replace:: 3.5mm output/input connector, 2W Internal Speaker
 
-.. _PPC/EPC-A8-70-HB-C:
+.. _product_link: https://chipsee.com/product/epca870hbc/
+
+.. |product_link| replace:: EPC/PPC-A8-70H-C
+
+.. _EPC/PPC-A8-70H-C:
 
 
 |product|

--- a/docs/source/PCs/ARM/AM335X/Manuals/Hardware/CS10600T101.rst
+++ b/docs/source/PCs/ARM/AM335X/Manuals/Hardware/CS10600T101.rst
@@ -52,6 +52,10 @@
 
 .. |audio| replace:: 3.5mm output/input connector, 2W Internal Speaker
 
+.. _product_link: https://chipsee.com/product/ppca8101r/
+
+.. |product_link| replace:: EPC/PPC-A8-101-R
+
 .. _EPC/PPC-A8-101-R:
 
 

--- a/docs/source/PCs/ARM/AM335X/Manuals/Hardware/CS10768T097.rst
+++ b/docs/source/PCs/ARM/AM335X/Manuals/Hardware/CS10768T097.rst
@@ -52,6 +52,10 @@
 
 .. |audio| replace:: 3.5mm output/input connector, 2W Internal Speaker
 
+.. _product_link: https://chipsee.com/product/epca897c/
+
+.. |product_link| replace:: PPC/EPC-A8-97-C
+
 .. _PPC/EPC-A8-97-C:
 
 

--- a/docs/source/PCs/ARM/AM335X/Manuals/Hardware/CS80480T050.rst
+++ b/docs/source/PCs/ARM/AM335X/Manuals/Hardware/CS80480T050.rst
@@ -52,6 +52,10 @@
 
 .. |audio| replace:: 3.5mm Audio In/Out Connector
 
+.. _product_link: https://chipsee.com/product/epca850c/
+
+.. |product_link| replace:: EPC/PPC-A8-50-C
+
 .. _EPC/PPC-A8-50-C:
 
 

--- a/docs/source/PCs/ARM/AM335X/Manuals/Hardware/CS80480T070.rst
+++ b/docs/source/PCs/ARM/AM335X/Manuals/Hardware/CS80480T070.rst
@@ -52,6 +52,10 @@
 
 .. |audio| replace:: 3.5mm output/input connector, 2W Internal Speaker
 
+.. _product_link: https://chipsee.com/product/epca870hbr/
+
+.. |product_link| replace:: PPC/EPC-A8-70-HB-R
+
 .. _PPC/EPC-A8-70-HB-R:
 
 

--- a/docs/source/PCs/ARM/AM335X/Manuals/Hardware/CS80600T080.rst
+++ b/docs/source/PCs/ARM/AM335X/Manuals/Hardware/CS80600T080.rst
@@ -52,6 +52,10 @@
 
 .. |audio| replace:: 3.5mm output/input connector, 2W Internal Speaker
 
+.. _product_link: https://chipsee.com/product/epca870hbr/
+
+.. |product_link| replace:: EPC/PPC-A8-80-R
+
 .. _EPC/PPC-A8-80-R:
 
 

--- a/docs/source/PCs/ARM/AM335X/Manuals/Hardware/Resources/ordering
+++ b/docs/source/PCs/ARM/AM335X/Manuals/Hardware/Resources/ordering
@@ -5,7 +5,7 @@ Chipsee products can be customized during the ordering process. The product will
 
 .. note::
   
-  You can order |Product| from the official |cstore|_ or from your nearest distributor.
+  You can order |product_link|_ from the official |cstore|_ or from your nearest distributor.
 
 Operating System
 ----------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ author = 'Randy'
 version = '1.1'
 
 # The full version, including alpha/beta/rc tags
-release = '05'
+release = '1.1'
 
 # -- General configuration ---------------------------------------------------
 # Add any Sphinx extension module names here, as strings. They can be
@@ -149,6 +149,10 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # tablecaption = 'below'
 pygments_style = "sphinx"
+
+# PDF output
+latex_engine = 'pdflatex'
+latex_logo = './Media/Chipsee_Logo_Full.png'
 
 # Sphinx internationalization details
 # language = "zh_CN"

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -4,3 +4,4 @@ Sphinx==4.3.1
 sphinx-material==0.0.35
 sphinx-prompt==1.5.0
 Sphinx-Substitution-Extensions==2020.9.30.0
+


### PR DESCRIPTION
I changed the manual name EPC/PPC-A8-70HB-C to EPC/PPC-A8-70H-C on the website. 
Performed these tasks:
- [x] change it throughout the documentation 
- [x] fix the documentation link
- [x] change the link in the ordering section of the documentation so that it leads to the product page