### PR TITLE
Change table CSS class.

### DIFF
--- a/docs/source/_static/css/material_custom.css
+++ b/docs/source/_static/css/material_custom.css
@@ -13,6 +13,15 @@ body,
         font-size: 16px!important;
         line-height: 1.5!important;
   }
+  
+  .md-typeset__table {
+    min-width: 100%;
+  }
+
+  .md-typeset table:not([class]) {
+    display: table;
+  }
+
 
   h1, h2, h3{
     font-family: 'Montserrat', sans-serif !important;


### PR DESCRIPTION
The table's CSS class has a weird behaviour, they do not get full width.

Even if I tried to add `:class:` to it, the CSS does not change, and remains to be ".md-typeset__table".

People have similar issue, check this: https://github.com/squidfunk/mkdocs-material/issues/175#issuecomment-616694465

This is a work around, this commit will make all tables in our doc to be full width. If you need a different width, the `width` in rst works now, it means you can change the width to be smaller than 100%, say 80% or 50%. And the table with a `width: 80%` is 80% of the full width.

This commit will affect all pages that include an html table.

[A preview after the changes](http://cd.jljgxx.com/PCs/ARM/RK3568/Manuals/Hardware/CS10600-RK3568-070P.html#ppc-a55-070)