### PR TITLE
PDF Improvement

### DIFF
--- a/custom_code.py
+++ b/custom_code.py
@@ -51,5 +51,52 @@ def main(**kwargs: BeautifulSoup) -> None:
         prod_img_tag = soup.find("div", attrs={"id": "cover_product_img_area"})
         prod_img_tag["style"] = f"background-image: url('{front_view_img}');"
 
+    remove_toc_number(soup)
+    remove_href_of_image(soup)
+
+def remove_toc_number(soup):
+    """
+    By default, the table of content numbering links like this:
+    1. PPC-CM4-050
+      1.1. Product Overview
+      ...
+      1.6. Connectivity 11
+        1.6.1. RS232/RS485/CAN
+      ...
+      1.14. Disclaimer
+      
+    This method removes the "1." at the start of each link like this:
+    PPC-CM4-050
+      1. Product Overview
+      ...
+      6. Connectivity 11
+        6.1. RS232/RS485/CAN
+      ...
+      14. Disclaimer
+    """
+    toc = soup.find("article", {"id": "doc-toc"})
+    all_a_with_num = toc.find_all('a', attrs={'data-numbering' : True})
+    for a_with_num in all_a_with_num:
+        a_with_num['data-numbering'] = a_with_num['data-numbering'][2:]
+
+def remove_href_of_image(soup):
+    """
+    By default, in PDF, images have a hyperlink to go to the docs.chipsee.com, because the HTML is:
+    <a class="reference internal" href="https://docs.chipsee.com/_images/x.jpg">
+      <img alt="power_img" class="align-middle" src="file:...///.../_images/CS10600RA4070P-D-Power.jpg" 
+      style="width: 720px;"/>
+    </a>
+    
+    This method removes the `<a class= href= ></a>` and 
+    keeps `<img alt= class= src= style= />` such that images in PDF are not clickable.
+    
+    Becomes: 
+    <img alt="power_img" class="align-middle" src="file:...///.../_images/CS10600RA4070P-D-Power.jpg" 
+    style="width: 720px;"/>
+    """
+    img_anchors = soup.find_all('a', href=re.compile('docs.chipsee.com\/_images'))
+    for img_anchor in img_anchors:
+        img_anchor.replaceWithChildren()
+
 if __name__ == "__main__":
     main()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,8 +147,9 @@ pygments_style = "perldoc"
 # Sphinx-PDF-Generate configurations
 pdfgen_verbose = False
 pdfgen_site_url = "https://docs.chipsee.com"
-#pdfgen_debug = True
-#pdfgen_debug_target = "PCs/Pi/Software/Debian.rst"
+# pdfgen_debug = True
+# pdfgen_debug_target = "PCs/Pi/Software/Debian.rst"
+# pdfgen_debug_target = "PCs/Pi/A72/Manuals/Hardware/CS10600RA4070P-D.rst"
 pdfgen_author = "Chipsee"
 pdfgen_copyright = copyright
 pdfgen_disclaimer = "Content can change at anytime. It's best to refer to website for latest information."


### PR DESCRIPTION
Remove the first "1." in table of content. ToC used to be 1. 1.1 1.2 1.2.1 ... 1.9, but there is not 2. or 2.1, this update removes that starting "1." and new ToC will be 1. 2. 3. 4.1 4.1.1 ... 9.

<img width="1523" alt="Screenshot 2023-12-13 at 11 16 28" src="https://github.com/Chipsee/Documentation/assets/10386624/3b6ddfe3-f11f-4772-bd90-7fd210fa3c97">

----

Remove href of images. Images used to be clickable, this update removes image href from PDFs, such that in PDF image will not be clickable anymore.

<img width="1767" alt="Screenshot 2023-12-13 at 12 37 02" src="https://github.com/Chipsee/Documentation/assets/10386624/e5cd9e2d-cbe2-4947-947e-8b65ca475e07">
