### PR TITLE
Add a Cookie consent banner while testing web analytics tools.

### DIFF
--- a/docs/source/_static/css/material_custom.css
+++ b/docs/source/_static/css/material_custom.css
@@ -592,3 +592,28 @@ caption, figcaption, p.caption {
 .md-nav--secondary ul li ul li {
   padding-left: 0.6rem !important
 }
+
+/* Style the GDPR Consent Banner */
+.gdpr-consent-banner {
+    z-index: 1;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background-color: #f0f0f0;
+    padding: 10px;
+    text-align: center;
+    box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
+    display: none;
+}
+
+/* Style the GDPR Consent Banner buttons */
+#accept-cookies,
+#decline-cookies {
+    padding: 0.5em 1.2em;
+    margin: 5px;
+    cursor: pointer;
+    color: red;
+    border: solid 1px red;
+    border-radius: 6px;
+}

--- a/docs/source/_static/js/material_custom.js
+++ b/docs/source/_static/js/material_custom.js
@@ -134,3 +134,50 @@ function addParamToThreeD() {
 addParamToThreeD();
 
 
+// Consent Banner logics starts
+
+// Get the consent banner element
+const consentBanner = document.getElementById('gdpr-consent-banner');
+
+// Get buttons for accepting and declining cookies
+const acceptCookiesBtn = document.getElementById('accept-cookies');
+
+// Function to hide the consent banner
+function showConsentBanner() {
+    consentBanner.style.display = 'block';
+}
+
+function hideConsentBanner() {
+    consentBanner.style.display = 'none';
+}
+
+function setConsentCookie() {
+    const expiryDate = new Date();
+    // Set the expiry date for the cookie (e.g., 1 year from now)
+    expiryDate.setFullYear(expiryDate.getFullYear() + 1);
+    // Define cookie content and attributes
+    const cookieContent = "consent=accepted; expires=" + expiryDate.toUTCString() + "; path=/";
+    // Set the cookie
+    document.cookie = cookieContent;
+}
+
+// Function to check if the consent cookie exists
+function checkConsentCookie() {
+    return document.cookie.split(';').some((item) => item.trim().startsWith('consent='));
+}
+
+// Event listener for accepting cookies
+acceptCookiesBtn.addEventListener('click', () => {
+    setConsentCookie();
+    hideConsentBanner();
+});
+
+window.onload = function () {
+    const consentCookieExists = checkConsentCookie();
+    if (!consentCookieExists) {
+        // Consent not given, show the banner or disable tracking
+        showConsentBanner();
+    }
+};
+
+// Consent banner logic ends.

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -36,6 +36,14 @@
     <!-- End Matomo Code -->
 {% endblock %}
 
+{%- block extrafooter %}
+    <!-- GDPR Consent Banner -->
+    <div id="gdpr-consent-banner" class="gdpr-consent-banner">
+        <p>We use cookies to ensure that we give you the best experience on our website. If you continue to use this site we will assume that you are happy with it. For more information please refer to <a href="https://chipsee.com/privacy/" class="text-secondary">our privacy policy</a>.</p>
+        <button id="accept-cookies">OK</button>
+    </div>
+{% endblock %}
+
 {%- block footer_scripts %}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
     <script async src="{{ pathto('_static/js/material_custom.js', 1) }}"></script>

--- a/docs/source/index.html
+++ b/docs/source/index.html
@@ -320,6 +320,11 @@
                     </div>
                 </div>
             </div>
+            <!-- GDPR Consent Banner -->
+            <div id="gdpr-consent-banner" class="gdpr-consent-banner">
+                <p>We use cookies to ensure that we give you the best experience on our website. If you continue to use this site we will assume that you are happy with it. For more information please refer to <a href="https://chipsee.com/privacy/" class="text-secondary">our privacy policy</a>.</p>
+                <button id="accept-cookies">OK</button>
+            </div>
         </footer>
 
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>


### PR DESCRIPTION
While testing web analytics tool, we should add a Cookie consent banner, because web analytics tool uses Cookie, although it's anonymous, users should be informed this site uses a web analytics tool.

<img width="504" alt="Screenshot 2023-12-14 at 08 33 47" src="https://github.com/Chipsee/Documentation/assets/10386624/0fcc10d5-0317-4b86-913a-92882369cd5b">
