### PR TITLE
Fix a bug where non-existing 3D model link appear in the doc.

### DIFF
--- a/docs/source/_static/js/material_custom.js
+++ b/docs/source/_static/js/material_custom.js
@@ -101,7 +101,7 @@ function fbxExists(fbxName) {
     let xhr = new XMLHttpRequest();
     xhr.open('HEAD', `/_static/3d_models/${fbxName}.fbx`, false);
     xhr.send();
-    return xhr.status != 404;
+    return xhr.status == 200;
 }
 
 // Add query param to let 3D js know what product it needs to display, open 3D page.


### PR DESCRIPTION
After 404 is handle by a 302 on the doc's hosting provider, the testing of whether a 3D model exists is not working. E.g. a product has PPC 3D model but not EPC 3D model, this 302 will tell it a EPC 3D model exist. After the fix, the non-existing EPC 3D model link will not appear anymore.