### PR TITLE
Rewrite search on index.html for moving to chipsee.com/docs

### DIFF
--- a/docs/source/index.html
+++ b/docs/source/index.html
@@ -111,7 +111,7 @@
                     </a>
                   </li>
                 </ul>
-                <form class="d-flex" role="search" action="/search.html?" method="GET">
+                <form class="d-flex" role="search" action="/docs/search.html?" method="GET">
                   <input class="form-control form-control-sm me-2" type="search" placeholder="Search" name="q" aria-label="Search">
                   <button class="btn btn-outline-success btn-sm" type="submit">Search</button>
                 </form>


### PR DESCRIPTION
The search on index.html won't work anymore in local development, it has to be in the subfolder of /docs/. 

But search within other pages generated by RST still works, both in development or in production environment.