### PR TITLE
New pypdf version breaks package, fix it to a previous version.

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -8,3 +8,4 @@ sphinx_design==0.2.0
 sphinx-pdf-generate
 sphinx-copybutton
 weasyprint==60.0
+pydyf==0.10.0


### PR DESCRIPTION
https://github.com/CourtBouillon/pydyf/releases/tag/v0.10.0