### PR TITLE
Fix USB description on CM5.

### DIFF
--- a/docs/source/PCs/Pi/A76/Manuals/Hardware/CS10600RA5070.rst
+++ b/docs/source/PCs/Pi/A76/Manuals/Hardware/CS10600RA5070.rst
@@ -58,7 +58,7 @@
 
 .. |camera_not_mount| replace:: The camera connector is supported but not mounted by default. Please contact us when placing an order if you need to use camera on the |product|.
 
-.. |USB_attention| replace:: 1\. These two USB host connectors can drive 500mA for each channel at most. |br| 2\. These |usb_hub_conflict| come from the same USB HUB. |br| 3\. When you connect this product to the HOST PC through the Type-C port, the USB HUB will be disabled. As a result, the |usb_hub_conflict| will not work.
+.. |USB_attention| replace:: These two USB host connectors can drive 500mA for each channel at most.
 
 .. |zigbee_des| replace:: No
 

--- a/docs/source/PCs/Pi/A76/Manuals/Hardware/CS12720RA5050.rst
+++ b/docs/source/PCs/Pi/A76/Manuals/Hardware/CS12720RA5050.rst
@@ -60,7 +60,7 @@
 
 .. |camera_not_mount| replace:: The camera connector is supported but not mounted by default. It's available on the PCB but not exposed on the case, please contact us when placing an order if you need to use camera on the |product|.
 
-.. |USB_attention| replace:: 1\. These two USB host connectors can drive 500mA for each channel at most. |br| 2\. These |usb_hub_conflict| come from the same USB HUB. |br| 3\. When you connect this product to the HOST PC through the Type-C port, the USB HUB will be disabled. As a result, the |usb_hub_conflict| will not work.
+.. |USB_attention| replace:: These two USB host connectors can drive 500mA for each channel at most.
 
 .. |zigbee_des| replace:: No
 

--- a/docs/source/PCs/Pi/A76/Manuals/Hardware/Resources/CS12800RA5101/base_replaces
+++ b/docs/source/PCs/Pi/A76/Manuals/Hardware/Resources/CS12800RA5101/base_replaces
@@ -38,7 +38,7 @@
 
 .. |camera_not_mount| replace:: The camera connector is supported but not mounted by default. Please contact us when placing an order if you need to use camera on the |product|.
 
-.. |USB_attention| replace:: 1\. These two USB host connectors can drive 500mA for each channel at most. |br| 2\. These two USB host connectors come from the same USB HUB.
+.. |USB_attention| replace:: These two USB host connectors can drive 500mA for each channel at most.
 
 .. |zigbee_des| replace:: No
 


### PR DESCRIPTION
5 inch, 7 inch single LAN, 10.1+ inch USB3.0 come from CM5 directly. 7 inch dual lan model's USB2.0 and USB-C shares a HUB.